### PR TITLE
FIX: Update URI logic for V3

### DIFF
--- a/run.py
+++ b/run.py
@@ -3,10 +3,13 @@
 import csv
 import datetime
 import copy
-import flywheel
 import json
 import logging
+
+import flywheel
 import jsonschema
+import re
+
 
 ERROR_LOG_FILENAME_SUFFIX = 'error.log.json'
 CSV_HEADERS = [
@@ -62,7 +65,7 @@ def get_uri(client, container):
         str: A uri that can be used to find the
             container
     """
-    first = ':'.join(client.get_config().site.api_url.split(':')[:-1])
+    first = get_uri_prefix(client.get_config().site.api_url)
     uri = None
     if container.container_type == 'project':
         uri = first + '/#/projects/{}'.format(container.id)
@@ -73,6 +76,20 @@ def get_uri(client, container):
     else:
         uri = first + '/#/projects/{}'.format(container.parents.project)
     return uri
+
+
+def get_uri_prefix(client_config_site_api_url):
+    """
+    Removes /api and port (i.e. :443) from client_config_site_api_url
+    Args:
+        client_config_site_api_url (str): the value for client.get_config().site.api_url
+
+    Returns:
+        str: the uri without /api or port information
+    """
+    remove_regex = r'(:[\d]+)?/api'
+    return_prefix = re.sub(remove_regex, '', client_config_site_api_url)
+    return return_prefix
 
 
 def add_additional_info(error_containers, client):

--- a/tests/unit_tests/test_get_uri.py
+++ b/tests/unit_tests/test_get_uri.py
@@ -20,7 +20,7 @@ class MockContainer(object):
 
 class MockClient(object):
     def get_config(self):
-        return mock.MagicMock(site=mock.MagicMock(api_url='https://hostname:port'))
+        return mock.MagicMock(site=mock.MagicMock(api_url='https://hostname:443/api'))
 
 
 def test_get_uri_for_project():
@@ -54,3 +54,11 @@ def test_get_uri_for_acquisition():
     uri = run.get_uri(client, acquisition)
     assert uri == 'https://hostname/#/projects/project_id/sessions/session_id?tab=data'
 
+def test_get_uri_prefix():
+    test_uri = 'https://covid19.flywheel.io/api'
+    expected = 'https://covid19.flywheel.io'
+    assert expected == run.get_uri_prefix(test_uri)
+
+    test_uri = 'https://ss.ce.flywheel.io:443/api'
+    expected = 'https://ss.ce.flywheel.io'
+    assert expected == run.get_uri_prefix(test_uri)


### PR DESCRIPTION
V3 uri values do not have a port, so the splitting logic was broken. Replaced by a re.sub on an optional capture group for port followed by `/api`